### PR TITLE
Add per-example PlotConfig, docstrings, and README catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 
 A set of scripts with customised graphs and plots in DearPyGUI.
 
+Each example under `examples/` defines a small **`PlotConfig`** dataclass (see the module’s `CONFIG`) so you can change titles, sizes, colors, and data ranges without hunting through layout code.
+
+## Examples
+
+- **`examples.bar_series`** — Grouped bar chart (student scores).
+- **`examples.shape_editor`** — Polygon shape editor on a custom series with drag points.
+- **`examples.custom_series_tooltip`** — Custom series with hover feedback and tooltip text.
+- **`examples.large_polygon_custom_series`** — Many polygons in a custom-series painter (opens the metrics window).
+- **`examples.stem_scatter_theme`** — Stem and scatter series with a shared plot theme.
+- **`examples.drag_lines_points`** — Drag lines and drag points on a plot.
+- **`examples.timeline_multiaxis`** — Long sine series, multiple Y axes, annotations from `timekeys.txt` at the repo root.
+- **`examples.screenshot`** — Save viewport or window frame buffers to PNG files.
+
 ### Reproduce
 
 From the repository root, install dependencies (Python 3 with `pip`):

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,5 +1,6 @@
 """Collection of DearPyGui plot examples.
 
-Run from the repository root, for example: python -m examples.bar_series
-See examples.index for a full list.
+Each module defines a ``PlotConfig`` dataclass (or ``CONFIG`` in ``screenshot``)
+for tunable defaults; run with ``python -m examples.<name>`` from the repo root.
+See ``python -m examples.index`` and the README *Examples* section for a catalog.
 """

--- a/examples/bar_series.py
+++ b/examples/bar_series.py
@@ -1,10 +1,30 @@
+"""Grouped bar series: multiple exam scores per student with custom X ticks.
+
+Run with: ``python -m examples.bar_series``. Adjust ``CONFIG`` to change
+viewport title, window size, and plot label without editing layout code.
+"""
+
+from dataclasses import dataclass
+
 import dearpygui.dearpygui as dpg
 
 from .helpers import run_app
 
 
+@dataclass
+class PlotConfig:
+    viewport_title: str = "Custom Title"
+    window_label: str = "Tutorial"
+    window_width: int = 400
+    window_height: int = 400
+    plot_label: str = "Bar Series"
+
+
+CONFIG = PlotConfig()
+
+
 def build_ui():
-    with dpg.plot(label="Bar Series", height=-1, width=-1):
+    with dpg.plot(label=CONFIG.plot_label, height=-1, width=-1):
         dpg.add_plot_legend()
 
         # create x axis
@@ -21,4 +41,9 @@ def build_ui():
 
 
 if __name__ == "__main__":
-    run_app(build_ui, title="Custom Title", window_label="Tutorial", window_kwargs={"width": 400, "height": 400})
+    run_app(
+        build_ui,
+        title=CONFIG.viewport_title,
+        window_label=CONFIG.window_label,
+        window_kwargs={"width": CONFIG.window_width, "height": CONFIG.window_height},
+    )

--- a/examples/custom_series_tooltip.py
+++ b/examples/custom_series_tooltip.py
@@ -1,9 +1,31 @@
+"""Custom series with per-point drawing and a hover-driven tooltip.
+
+Run with: ``python -m examples.custom_series_tooltip``. Edit ``CONFIG`` to
+change sample data, plot size, and window tags.
+"""
+
+from dataclasses import dataclass
+
 import dearpygui.dearpygui as dpg
 
 from .helpers import run_app
 
-x_data = [0.0, 1.0, 2.0, 4.0, 5.0]
-y_data = [0.0, 10.0, 20.0, 40.0, 50.0]
+
+@dataclass
+class PlotConfig:
+    viewport_title: str = "DearPyGui Plot Example"
+    window_label: str = "Tutorial"
+    window_tag: str = "plot3_window"
+    plot_label: str = "Custom Series"
+    plot_height: int = 400
+    x_data: tuple[float, ...] = (0.0, 1.0, 2.0, 4.0, 5.0)
+    y_data: tuple[float, ...] = (0.0, 10.0, 20.0, 40.0, 50.0)
+
+
+CONFIG = PlotConfig()
+
+x_data = list(CONFIG.x_data)
+y_data = list(CONFIG.y_data)
 
 def callback(sender, app_data):
 
@@ -31,7 +53,7 @@ def callback(sender, app_data):
 
 def build_ui():
     dpg.add_text("Hover an item for a custom tooltip!")
-    with dpg.plot(label="Custom Series", height=400, width=-1):
+    with dpg.plot(label=CONFIG.plot_label, height=CONFIG.plot_height, width=-1):
         dpg.add_plot_legend()
         dpg.add_plot_axis(dpg.mvXAxis)
         with dpg.plot_axis(dpg.mvYAxis):
@@ -43,8 +65,8 @@ def build_ui():
 if __name__ == "__main__":
     run_app(
         build_ui,
-        title="DearPyGui Plot Example",
-        window_label="Tutorial",
-        window_tag="plot3_window",
-        set_primary_window_tag="plot3_window",
+        title=CONFIG.viewport_title,
+        window_label=CONFIG.window_label,
+        window_tag=CONFIG.window_tag,
+        set_primary_window_tag=CONFIG.window_tag,
     )

--- a/examples/drag_lines_points.py
+++ b/examples/drag_lines_points.py
@@ -1,6 +1,26 @@
+"""Drag lines and drag points on a plot (no axis parent for drag items).
+
+Run with: ``python -m examples.drag_lines_points``. Change ``CONFIG`` for window
+width, plot height, and default drag colors.
+"""
+
+from dataclasses import dataclass
+
 import dearpygui.dearpygui as dpg
 
 from .helpers import run_app
+
+
+@dataclass
+class PlotConfig:
+    window_width: int = 400
+    plot_height: int = 400
+    drag_line_color_a: tuple[int, int, int, int] = (255, 0, 0, 255)
+    drag_line_color_b: tuple[int, int, int, int] = (255, 255, 0, 255)
+    drag_point_color: tuple[int, int, int, int] = (255, 0, 255, 255)
+
+
+CONFIG = PlotConfig()
 
 
 class DraggablePoints:
@@ -35,17 +55,17 @@ def custom_series_callback(sender, app_data):
 
 def build_ui():
     dpg.add_button(label="plot", callback=add_points_to_plot)
-    with dpg.plot(tag="plot1", label="plot1", height=400, width=-1):
+    with dpg.plot(tag="plot1", label="plot1", height=CONFIG.plot_height, width=-1):
         dpg.add_plot_legend()
         dpg.add_plot_axis(dpg.mvXAxis, label="x")
         dpg.add_plot_axis(dpg.mvYAxis, label="y")
 
         # drag lines/points belong to the plot NOT axis
-        dpg.add_drag_line(label="dline1", color=[255, 0, 0, 255])
-        dpg.add_drag_line(label="dline2", color=[255, 255, 0, 255], vertical=False)
-        dpg.add_drag_point(label="dpoint1", color=[255, 0, 255, 255])
-        dpg.add_drag_point(label="dpoint2", color=[255, 0, 255, 255])
+        dpg.add_drag_line(label="dline1", color=list(CONFIG.drag_line_color_a))
+        dpg.add_drag_line(label="dline2", color=list(CONFIG.drag_line_color_b), vertical=False)
+        dpg.add_drag_point(label="dpoint1", color=list(CONFIG.drag_point_color))
+        dpg.add_drag_point(label="dpoint2", color=list(CONFIG.drag_point_color))
 
 
 if __name__ == "__main__":
-    run_app(build_ui, window_kwargs={"width": 400})
+    run_app(build_ui, window_kwargs={"width": CONFIG.window_width})

--- a/examples/helpers.py
+++ b/examples/helpers.py
@@ -1,3 +1,5 @@
+"""Shared DearPyGui bootstrap: viewport, optional main window, event loop."""
+
 import dearpygui.dearpygui as dpg
 
 

--- a/examples/index.py
+++ b/examples/index.py
@@ -1,4 +1,8 @@
-"""Print available examples and how to run them. Usage: python -m examples.index"""
+"""Print available examples and how to run them.
+
+Usage: ``python -m examples.index`` from the repository root.
+Descriptions mirror the README *Examples* section.
+"""
 
 AVAILABLE_EXAMPLES = {
     "bar_series": "Grouped bar chart (student scores)",

--- a/examples/large_polygon_custom_series.py
+++ b/examples/large_polygon_custom_series.py
@@ -1,14 +1,33 @@
+"""Stress-test custom series: many polygons drawn inside a custom-series callback.
+
+Run with: ``python -m examples.large_polygon_custom_series``. Use ``CONFIG`` to
+tune polygon count, colors, axis clamp range, and plot size before clicking
+*Create items*.
+"""
+
 from __future__ import annotations
+from dataclasses import dataclass
+
 import dearpygui.dearpygui as dpg
 
 from .helpers import run_app
 
-POLYGONS:int = 10_000 # the amount of polygons to be generated
-POLYGON = ((0.,0.),(0.,1.),(1.,1.),(1.,0.)) # shape of the polygon
-POLYGON_COLOR = (0,0,0)
 
-MAX_RANGE:float = 750.
-MIN_RANGE:float = -MAX_RANGE
+@dataclass
+class PlotConfig:
+    viewport_title: str = "Plot with large Custom Series Example"
+    primary_window_tag: str = "primary_window"
+    primary_window_label: str = "primary_window"
+    polygon_count: int = 10_000
+    polygon_template: tuple[tuple[float, float], ...] = ((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0))
+    polygon_color: tuple[int, int, int] = (0, 0, 0)
+    max_range: float = 750.0
+    plot_width: int = 500
+    plot_height: int = 500
+    toolbar_spacing: int = 375
+
+
+CONFIG = PlotConfig()
 
 polygons:list[tuple] = []
 drawn_polygons:list[str|int] = []
@@ -35,8 +54,8 @@ def custom_series_callback(sender, app_data):
             if len(points) >= 3:
                 drawn_polygons.append(dpg.draw_polygon(
                     points=points,
-                    color=POLYGON_COLOR,
-                    fill=POLYGON_COLOR,
+                    color=CONFIG.polygon_color,
+                    fill=CONFIG.polygon_color,
                     thickness=0
                 ))
         
@@ -50,30 +69,32 @@ def custom_series_callback(sender, app_data):
 
 
 def calculate_points(polygon, difference_x:float, difference_y:float, x0:float, y0:float) -> list[list[float,float]]:
+    lo = -CONFIG.max_range
+    hi = CONFIG.max_range
     points = []
     for x_original, y_original in polygon:
-        if  MIN_RANGE < (x_new := ((x_original * difference_x) + x0)) < MAX_RANGE \
-        and MIN_RANGE < (y_new := ((y_original * difference_y) + y0)) < MAX_RANGE:
+        if  lo < (x_new := ((x_original * difference_x) + x0)) < hi \
+        and lo < (y_new := ((y_original * difference_y) + y0)) < hi:
             points.append([x_new, y_new])
 
     return points
 
 
 def create_items():
-    for i in range(POLYGONS):
+    for i in range(CONFIG.polygon_count):
         polygons.append(
-            tuple((x+i,y+i) for x,y in POLYGON)
+            tuple((x+i,y+i) for x,y in CONFIG.polygon_template)
         )
 
 def build_ui():
-    with dpg.group(horizontal=True, horizontal_spacing=375):
+    with dpg.group(horizontal=True, horizontal_spacing=CONFIG.toolbar_spacing):
         dpg.add_button(
             label="Create items",
             callback=create_items,
             width=100
         )
         dpg.add_text(tag="txt_output")
-    with dpg.plot(width=500, height=500, tag="plot"):
+    with dpg.plot(width=CONFIG.plot_width, height=CONFIG.plot_height, tag="plot"):
         dpg.add_plot_axis(axis=dpg.mvXAxis)
         with dpg.plot_axis(axis=dpg.mvYAxis):
             dpg.add_custom_series(
@@ -87,9 +108,9 @@ def build_ui():
 if __name__ == '__main__':
     run_app(
         build_ui,
-        title='Plot with large Custom Series Example',
-        window_tag="primary_window",
-        window_kwargs={"label": "primary_window"},
-        set_primary_window_tag="primary_window",
+        title=CONFIG.viewport_title,
+        window_tag=CONFIG.primary_window_tag,
+        window_kwargs={"label": CONFIG.primary_window_label},
+        set_primary_window_tag=CONFIG.primary_window_tag,
         show_metrics=True,
     )

--- a/examples/screenshot.py
+++ b/examples/screenshot.py
@@ -1,32 +1,53 @@
+"""Capture the viewport or a single window to PNG files via frame buffers.
+
+Run with: ``python -m examples.screenshot``. Set ``CONFIG`` for viewport title
+and output filenames for the demo buttons.
+"""
+
 from __future__ import annotations
+from dataclasses import dataclass
+
 import dearpygui.dearpygui as dpg
 from PIL import Image
 
 from .helpers import run_app
 
 
+@dataclass
+class PlotConfig:
+    viewport_title: str = "Screenshot Example"
+    inner_window_tag: str = "window"
+    inner_window_label: str = "Screenshot Example"
+    viewport_png: str = "screenshot_viewport.png"
+    window_png: str = "screenshot_window.png"
+    window_crop_png: str = "screenshot_window_edit.png"
+
+
+CONFIG = PlotConfig()
+
+
 def picture_of_window(_, buffer:dpg.mvBuffer):
-    x,y = dpg.get_item_pos("window")
-    width = dpg.get_item_width("window")
-    height = dpg.get_item_height("window")
+    x,y = dpg.get_item_pos(CONFIG.inner_window_tag)
+    width = dpg.get_item_width(CONFIG.inner_window_tag)
+    height = dpg.get_item_height(CONFIG.inner_window_tag)
 
     image = Image.frombuffer(
         mode="RGBA",
         size=(buffer.get_width(), buffer.get_height()),
         data=buffer
     )
-    image.save("screenshot_window.png")
+    image.save(CONFIG.window_png)
 
     image_edit = image.crop((x,y, width, height))
-    image_edit.save("screenshot_window_edit.png")
+    image_edit.save(CONFIG.window_crop_png)
 
 
 def build_ui():
-    with dpg.window(tag="window",label="Screenshot Example"):
+    with dpg.window(tag=CONFIG.inner_window_tag, label=CONFIG.inner_window_label):
         dpg.add_text("Hello world!")
         dpg.add_button(
             label="Press me, to take a screenshot of the viewport",
-            callback=lambda : dpg.output_frame_buffer(file="screenshot_viewport.png")
+            callback=lambda : dpg.output_frame_buffer(file=CONFIG.viewport_png)
         )
         dpg.add_button(
             label="Press me, to take a screenshot of this window",
@@ -35,4 +56,4 @@ def build_ui():
 
 
 if __name__ == "__main__":
-    run_app(build_ui, title="Screenshot Example", wrap_window=False)
+    run_app(build_ui, title=CONFIG.viewport_title, wrap_window=False)

--- a/examples/shape_editor.py
+++ b/examples/shape_editor.py
@@ -1,9 +1,27 @@
 
+"""Polygon shape editor: draw shapes on a custom series and edit vertices with drag points.
+
+Run with: ``python -m examples.shape_editor``. Tweak ``CONFIG`` for viewport
+and primary-window tags used by this layout.
+"""
+
 from __future__ import annotations
 import dearpygui.dearpygui as dpg
 from dataclasses import dataclass, field
 
 from .helpers import run_app
+
+
+@dataclass
+class PlotConfig:
+    viewport_title: str = "Plot as Shape Editor"
+    primary_window_tag: str = "PrimaryWindow"
+    primary_window_label: str = "PrimaryWindow"
+    editor_plot_width: int = 500
+    editor_plot_height: int = 500
+
+
+CONFIG = PlotConfig()
 
 
 stored_shapes: dict[str, Shape] = {}
@@ -104,7 +122,7 @@ def custom_series_painter(sender,app_data):
 def build_ui():
     with dpg.group(horizontal=True, tag="LytMain"):
         with dpg.group(tag="LytCol1"):
-            with dpg.plot(tag="PlotEditor", width=500, height=500):
+            with dpg.plot(tag="PlotEditor", width=CONFIG.editor_plot_width, height=CONFIG.editor_plot_height):
                 dpg.add_plot_axis(axis=dpg.mvXAxis, tag="PlotAxisX")
                 with dpg.plot_axis(axis=dpg.mvYAxis, tag="PlotAxisY"):
                     dpg.add_custom_series(x= [0.,1.], y= [0.,1.], channel_count=2, callback=custom_series_painter)
@@ -131,8 +149,8 @@ def build_ui():
 if __name__ == '__main__':
     run_app(
         build_ui,
-        title="Plot as Shape Editor",
-        window_tag="PrimaryWindow",
-        window_kwargs={"label": "PrimaryWindow"},
-        set_primary_window_tag="PrimaryWindow",
+        title=CONFIG.viewport_title,
+        window_tag=CONFIG.primary_window_tag,
+        window_kwargs={"label": CONFIG.primary_window_label},
+        set_primary_window_tag=CONFIG.primary_window_tag,
     )

--- a/examples/stem_scatter_theme.py
+++ b/examples/stem_scatter_theme.py
@@ -1,18 +1,40 @@
+"""Stem and scatter series sharing a plot theme (markers and colors).
+
+Run with: ``python -m examples.stem_scatter_theme``. Adjust ``CONFIG`` for viewport
+title, window size, sample count, and plot label.
+"""
+
+from dataclasses import dataclass
+
 import dearpygui.dearpygui as dpg
 from math import sin
 
 from .helpers import run_app
 
 
+@dataclass
+class PlotConfig:
+    viewport_title: str = "Custom Title"
+    window_label: str = "Tutorial"
+    window_width: int = 500
+    window_height: int = 400
+    sample_count: int = 100
+    plot_label: str = "Line Series"
+
+
+CONFIG = PlotConfig()
+
+
 def build_ui():
+    n = CONFIG.sample_count
     sindatax = []
     sindatay = []
-    for i in range(0, 100):
-        sindatax.append(i / 100)
-        sindatay.append(0.5 + 0.5 * sin(50 * i / 100))
+    for i in range(0, n):
+        sindatax.append(i / n)
+        sindatay.append(0.5 + 0.5 * sin(50 * i / n))
     sindatay2 = []
-    for i in range(0, 100):
-        sindatay2.append(2 + 0.5 * sin(50 * i / 100))
+    for i in range(0, n):
+        sindatay2.append(2 + 0.5 * sin(50 * i / n))
 
     # create a theme for the plot
     with dpg.theme(tag="plot_theme"):
@@ -27,7 +49,7 @@ def build_ui():
             dpg.add_theme_style(dpg.mvPlotStyleVar_MarkerSize, 4, category=dpg.mvThemeCat_Plots)
 
     # create plot
-    with dpg.plot(tag="plot", label="Line Series", height=-1, width=-1):
+    with dpg.plot(tag="plot", label=CONFIG.plot_label, height=-1, width=-1):
         # optionally create legend
         dpg.add_plot_legend()
         # REQUIRED: create x and y axes
@@ -44,4 +66,9 @@ def build_ui():
 
 
 if __name__ == "__main__":
-    run_app(build_ui, title="Custom Title", window_label="Tutorial", window_kwargs={"width": 500, "height": 400})
+    run_app(
+        build_ui,
+        title=CONFIG.viewport_title,
+        window_label=CONFIG.window_label,
+        window_kwargs={"width": CONFIG.window_width, "height": CONFIG.window_height},
+    )

--- a/examples/timeline_multiaxis.py
+++ b/examples/timeline_multiaxis.py
@@ -1,5 +1,13 @@
-# vecnode 28-06-2023
+"""Dense line data with multiple Y axes, drag gadgets, and optional time annotations.
 
+Original sketch: vecnode 28-06-2023.
+
+Run with: ``python -m examples.timeline_multiaxis``. Annotations load from
+``timekeys.txt`` at the repository root; adjust ``CONFIG`` for viewport size,
+sample count, and that filename.
+"""
+
+from dataclasses import dataclass
 from pathlib import Path
 
 import dearpygui.dearpygui as dpg
@@ -9,14 +17,21 @@ from .helpers import run_app
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# window
 
-window_width = 1280
-window_height = 600
+@dataclass
+class PlotConfig:
+    viewport_title: str = " "
+    viewport_width: int = 1280
+    viewport_height: int = 600
+    line_point_count: int = 10000
+    timekeys_file: str = "timekeys.txt"
+
+
+CONFIG = PlotConfig()
 
 sindatax = []
 sindatay = []
-for i in range(0, 10000):
+for i in range(0, CONFIG.line_point_count):
     sindatax.append(i / 500)
     sindatay.append(0.5 + 0.5 * sin(50 * i / 1000))
 
@@ -54,7 +69,7 @@ def callback1(sender, data):
 
 
 def callback3(sender, data):
-    create_annotations_from_file(str(_REPO_ROOT / "timekeys.txt"), "mainplot", color=[255, 255, 255, 255])
+    create_annotations_from_file(str(_REPO_ROOT / CONFIG.timekeys_file), "mainplot", color=[255, 255, 255, 255])
 
 
 
@@ -67,8 +82,9 @@ def print_val(sender):
     print(dpg.get_value(sender))
 
 def build_ui():
-    with dpg.window(label="main_window", tag="main_window", pos=(0,0), no_close=True, no_move=True, no_resize=True, no_title_bar=True, no_collapse=True, no_scrollbar=True, width=window_width, height=window_height):
-        with dpg.window(label="second_window", tag="second_window", pos=(0,0), no_close=True, no_move=True, no_resize=True, no_title_bar=True, no_collapse=True, no_scrollbar=True, width=window_width, height=window_height):
+    w, h = CONFIG.viewport_width, CONFIG.viewport_height
+    with dpg.window(label="main_window", tag="main_window", pos=(0,0), no_close=True, no_move=True, no_resize=True, no_title_bar=True, no_collapse=True, no_scrollbar=True, width=w, height=h):
+        with dpg.window(label="second_window", tag="second_window", pos=(0,0), no_close=True, no_move=True, no_resize=True, no_title_bar=True, no_collapse=True, no_scrollbar=True, width=w, height=h):
             with dpg.group(horizontal=True):
                 with dpg.child_window(width=100):
                     dpg.add_button(label="overview", callback=callback1, width=-1)
@@ -102,9 +118,9 @@ def build_ui():
 if __name__ == "__main__":
     run_app(
         build_ui,
-        title=' ',
-        width=window_width,
-        height=window_height,
+        title=CONFIG.viewport_title,
+        width=CONFIG.viewport_width,
+        height=CONFIG.viewport_height,
         wrap_window=False,
         set_primary_window_tag="main_window",
     )


### PR DESCRIPTION
Introduce a dataclass PlotConfig (and CONFIG singleton) in each example module for viewport/window/plot parameters and key tunables (colors, sample counts, paths). Wire build_ui and run_app calls to CONFIG.

Document each module with a short top-level docstring; extend package __init__, helpers, and index help text. Add README Examples section aligned with examples.index.

Implements https://github.com/vecnode/dearpygui-plots/issues/3
